### PR TITLE
examples/kv: remove roles 'namespace' parameter

### DIFF
--- a/examples/kv/deployment.yaml
+++ b/examples/kv/deployment.yaml
@@ -11,7 +11,6 @@ apiVersion: tarantool.io/v1alpha1
 kind: Role
 metadata:
   name: storage
-  namespace: default
   labels:
     tarantool.io/cluster-id: "examples-kv-cluster"
     tarantool.io/role: "storage"
@@ -25,7 +24,6 @@ apiVersion: tarantool.io/v1alpha1
 kind: Role
 metadata:
   name: routers
-  namespace: default
   labels:
     tarantool.io/cluster-id: "examples-kv-cluster"
     tarantool.io/role: "router"

--- a/test/e2e/scenario/basic.yaml
+++ b/test/e2e/scenario/basic.yaml
@@ -11,7 +11,6 @@ apiVersion: tarantool.io/v1alpha1
 kind: Role
 metadata:
   name: storage
-  namespace: default
   labels:
     tarantool.io/cluster-id: "examples-kv-cluster"
     tarantool.io/role: "storage"
@@ -25,7 +24,6 @@ apiVersion: tarantool.io/v1alpha1
 kind: Role
 metadata:
   name: routers
-  namespace: default
   labels:
     tarantool.io/cluster-id: "examples-kv-cluster"
     tarantool.io/role: "router"


### PR DESCRIPTION
operator is watching for changes in namespace where it's running but `examples/kv` Role's `namespace` is hardcoded to `default` making out of the box example broken when running not in `default` namespace. 

same issue with e2e test resources but tests working because resources namespace is forced to test namespace prior to running suite