### PR TITLE
Support configurable domain cluster name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+- Support custom cluster domain name via variable `ClusterDomainName` in cartrige chart `values.yaml`

--- a/examples/kv/helm-chart/templates/deployment.yaml
+++ b/examples/kv/helm-chart/templates/deployment.yaml
@@ -53,6 +53,7 @@ spec:
     metadata:
       labels:
         tarantool.io/cluster-id: {{ $.Values.ClusterName }}
+        tarantool.io/cluster-domain-name: "{{ $.Values.ClusterDomainName }}"
         tarantool.io/pod-template: "{{ .RoleName }}-pod-template"
         tarantool.io/useVshardGroups: "0"
         environment: "{{ $.Values.ClusterEnv }}"
@@ -114,7 +115,7 @@ spec:
                 fieldRef:
                   fieldPath: metadata.name
             - name: TARANTOOL_ADVERTISE_HOST
-              value: "$(TARANTOOL_ADVERTISE_TMP).{{ $.Values.ClusterName }}.{{ $.Release.Namespace }}.svc.cluster.local"
+              value: "$(TARANTOOL_ADVERTISE_TMP).{{ $.Values.ClusterName }}.{{ $.Release.Namespace }}.svc.{{ $.Values.ClusterDomainName }}"
             - name: TARANTOOL_ADVERTISE_URI
               value: "$(TARANTOOL_ADVERTISE_HOST):3301"
             - name: TARANTOOL_PROBE_URI_TIMEOUT

--- a/examples/kv/helm-chart/values.yaml
+++ b/examples/kv/helm-chart/values.yaml
@@ -2,6 +2,7 @@
 
 ClusterEnv: dev
 ClusterName: examples-kv-cluster
+ClusterDomainName: cluster.local
 
 image:
   repository: tarantool/tarantool-operator-examples-kv

--- a/pkg/topology/builtin.go
+++ b/pkg/topology/builtin.go
@@ -191,9 +191,17 @@ func GetRoles(pod *corev1.Pod) ([]string, error) {
 // Join comment
 func (s *BuiltInTopologyService) Join(pod *corev1.Pod) error {
 
-	advURI := fmt.Sprintf("%s.%s.%s.svc.cluster.local:3301", pod.GetObjectMeta().GetName(), s.clusterID, pod.GetObjectMeta().GetNamespace())
-
 	thisPodLabels := pod.GetLabels()
+	clusterDomainName, ok := thisPodLabels["tarantool.io/cluster-domain-name"]
+	if !ok {
+		clusterDomainName = "cluster.local"
+	}
+
+	advURI := fmt.Sprintf("%s.%s.%s.svc.%s:3301",
+		pod.GetObjectMeta().GetName(),      // Instance name
+		s.clusterID,                        // Cartridge cluster name
+		pod.GetObjectMeta().GetNamespace(), // Namespace
+		clusterDomainName)                  // Cluster domain name
 
 	replicasetUUID, ok := thisPodLabels["tarantool.io/replicaset-uuid"]
 	if !ok {


### PR DESCRIPTION
By default domain cluster name is `cluster.local`.
To change add variable `ClusterDomainName` to cartridge `values.yaml`. For example, :
```yaml
ClusterEnv: dev
ClusterName: test-app
ClusterDomainName: domain.name
...
```

Using the minikube for testing: 
```
minikube start --dns-domain='custom.domain' --extra-config='kubelet.cluster-domain=custom.domain'
```

