### PR TITLE
helm charts: set a limit on CPU and memory usage in the operator chart

### DIFF
--- a/ci/helm-chart/templates/deployment.yaml
+++ b/ci/helm-chart/templates/deployment.yaml
@@ -19,6 +19,10 @@ spec:
       containers:
         - name: tarantool-operator
           image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+          resources:
+            limits:
+              cpu: "{{ .Values.limits.CPUallocation }}"
+              memory: "{{ .Values.limits.MemoryMB }}M"
           command:
             - tarantool-operator
           env:

--- a/ci/helm-chart/values.yaml
+++ b/ci/helm-chart/values.yaml
@@ -6,3 +6,7 @@ image:
   repository: tarantool/tarantool-operator
   tag: 0.0.6
   pullPolicy: IfNotPresent
+
+limits:
+  CPUallocation: 0.5
+  MemoryMB: 256


### PR DESCRIPTION
Limits can be configured via `values.yaml` file:

```yaml
# Default values
limits:
  CPUallocation: 0.5
  MemoryMB: 256
```