### PR TITLE
cartridge helm chart: set default volumeMount to /var/lib/tarantool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,3 +10,4 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - Support custom cluster domain name via variable `ClusterDomainName` in cartrige chart `values.yaml`
 - New chart for deploying ready-to-use crud based application
+- Ability to change TARANTOOL_WORKDIR in the Cartridge helm chart and the **default value is set to** `/var/lib/tarantool`

--- a/examples/kv/helm-chart/templates/deployment.yaml
+++ b/examples/kv/helm-chart/templates/deployment.yaml
@@ -79,7 +79,7 @@ spec:
           image: "{{ $.Values.image.repository }}:{{ $.Values.image.tag }}"
           volumeMounts:
             - name: www
-              mountPath: "/data"
+              mountPath: "{{ $.Values.TarantoolWorkDir }}"
           resources:
             requests:
               cpu: "{{ .CPUallocation }}"
@@ -110,6 +110,8 @@ spec:
               value: "{{ mul .MemtxMemoryMB 1048576 }}"
             - name: TARANTOOL_BUCKET_COUNT
               value: "30000"
+            - name: TARANTOOL_WORKDIR
+              value: "{{ $.Values.TarantoolWorkDir }}"
             - name: TARANTOOL_ADVERTISE_TMP
               valueFrom:
                 fieldRef:

--- a/examples/kv/helm-chart/values.yaml
+++ b/examples/kv/helm-chart/values.yaml
@@ -3,6 +3,7 @@
 ClusterEnv: dev
 ClusterName: examples-kv-cluster
 ClusterDomainName: cluster.local
+TarantoolWorkDir: /var/lib/tarantool
 
 image:
   repository: tarantool/tarantool-operator-examples-kv


### PR DESCRIPTION
CartridgeCLI creates containers with a datadir `/var/lib/tarantool/` by default.
Use this value by default and add ability to change this parameter.