### PR TITLE
operator: strict verb restrictions in rbac role

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - Integration test for cluster_controller written with envtest and ginkgo
 
+### Changed
+- Requested verbs for a RBAC role Tarantool: remove all * verbs and resources
+
 ### Fixed
 - Not working update of replicaset roles
 

--- a/ci/helm-chart/templates/role.yaml
+++ b/ci/helm-chart/templates/role.yaml
@@ -15,7 +15,13 @@ rules:
   - configmaps
   - secrets
   verbs:
-  - '*'
+  - get
+  - create
+  - update
+  - watch
+  - list
+  - patch
+  - delete
 - apiGroups:
   - apps
   resources:
@@ -24,7 +30,13 @@ rules:
   - replicasets
   - statefulsets
   verbs:
-  - '*'
+  - get
+  - create
+  - update
+  - watch
+  - list
+  - patch
+  - delete
 - apiGroups:
   - monitoring.coreos.com
   resources:
@@ -43,10 +55,15 @@ rules:
 - apiGroups:
   - tarantool.io
   resources:
-  - '*'
   - clusters
   - roles
   - statefulsettemplatespecs
   - replicasettemplates
   verbs:
-  - '*'
+  - get
+  - create
+  - update
+  - watch
+  - list
+  - patch
+  - delete


### PR DESCRIPTION
Strict verb restrictions in RBAC role. Remove all '*' verbs and resources.