### PR TITLE
Add lua memory reserve

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Integration test for cluster_controller written with envtest and ginkgo
 - Description of failover setting in the Cartridge Kubernetes guide
 - Section to troubleshooting about CrashLoopBackOff
+- Lua memory reserve for tarantool containers
 
 ### Changed
 - Requested verbs for a RBAC role Tarantool: remove all * verbs and resources

--- a/examples/kv/helm-chart/templates/deployment.yaml
+++ b/examples/kv/helm-chart/templates/deployment.yaml
@@ -83,10 +83,10 @@ spec:
           resources:
             requests:
               cpu: "{{ .CPUallocation }}"
-              memory: "{{ .MemtxMemoryMB }}M"
+              memory: "{{ add .MemtxMemoryMB $.Values.LuaMemoryReserveMB }}M"
             limits:
               cpu: "{{ .CPUallocation }}"
-              memory: "{{ .MemtxMemoryMB }}M"
+              memory: "{{ add .MemtxMemoryMB $.Values.LuaMemoryReserveMB }}M"
           ports:
             - containerPort: 3301
               protocol: TCP

--- a/examples/kv/helm-chart/values.yaml
+++ b/examples/kv/helm-chart/values.yaml
@@ -4,6 +4,7 @@ ClusterEnv: dev
 ClusterName: examples-kv-cluster
 ClusterDomainName: cluster.local
 TarantoolWorkDir: /var/lib/tarantool
+LuaMemoryReserveMB: 2048
 
 image:
   repository: tarantool/tarantool-operator-examples-kv


### PR DESCRIPTION
Currently container limits/requests are set according to the memix size. But the limits don't take into account that lua also consumes memory.

I added a variable `LuaMemoryReserveMB` to cartridge chart in which you can specify the size of lua ram reserve. The default is 2Gb.