### PR TITLE
Fix flaky role controller unit test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Not working update of replicaset roles
 - Not working update of container env vars
 - Problem with a non-existent leader of cluster
+- Flaky role_controller unit test
 
 ## [0.0.8] - 2020-12-16
 

--- a/pkg/controller/role/role_test.go
+++ b/pkg/controller/role/role_test.go
@@ -95,7 +95,14 @@ var _ = Describe("role_controller unit testing", func() {
 				sts := &appsv1.StatefulSet{}
 				Eventually(
 					func() bool {
-						return k8sClient.Get(ctx, client.ObjectKey{Name: stsName, Namespace: namespace}, sts) == nil
+						if k8sClient.Get(ctx, client.ObjectKey{Name: stsName, Namespace: namespace}, sts) != nil {
+							return false
+						}
+						if sts.ObjectMeta.Annotations["tarantool.io/rolesToAssign"] == "" ||
+							sts.Spec.Template.Annotations["tarantool.io/rolesToAssign"] == "" {
+							return false
+						}
+						return true
 					},
 					time.Second*10, time.Millisecond*500,
 				).Should(BeTrue())


### PR DESCRIPTION
The role controller does not set annotations simultaneously with the creation of the statefulset, so we need to check that the annotations are created.