### PR TITLE
fix: add Namespace to ListOptions in List calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Refactor project structure, all helm charts are collected in one place
 - Update crds api version from `apiextensions.k8s.io/v1beta1` to `apiextensions.k8s.io/v1`
 
+### Fixed
+
+- Operator was not able to manage multiple cartridge clusters in multiple namespaces
+
 ## [0.0.9] - 2021-03-30
 
 ### Added

--- a/controllers/cluster_controller.go
+++ b/controllers/cluster_controller.go
@@ -138,7 +138,7 @@ func (r *ClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	}
 
 	roleList := &tarantooliov1alpha1.RoleList{}
-	if err := r.List(context.TODO(), roleList, &client.ListOptions{LabelSelector: clusterSelector}); err != nil {
+	if err := r.List(context.TODO(), roleList, &client.ListOptions{LabelSelector: clusterSelector, Namespace: req.NamespacedName.Namespace}); err != nil {
 		if errors.IsNotFound(err) {
 			return ctrl.Result{RequeueAfter: time.Duration(5 * time.Second)}, nil
 		}
@@ -221,7 +221,7 @@ func (r *ClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	}
 
 	stsList := &appsv1.StatefulSetList{}
-	if err := r.List(context.TODO(), stsList, &client.ListOptions{LabelSelector: clusterSelector}); err != nil {
+	if err := r.List(context.TODO(), stsList, &client.ListOptions{LabelSelector: clusterSelector, Namespace: req.NamespacedName.Namespace}); err != nil {
 		if errors.IsNotFound(err) {
 			return ctrl.Result{RequeueAfter: time.Duration(5 * time.Second)}, nil
 		}

--- a/controllers/role_controller.go
+++ b/controllers/role_controller.go
@@ -102,7 +102,7 @@ func (r *RoleReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 	}
 
 	stsList := &appsv1.StatefulSetList{}
-	if err := r.List(context.TODO(), stsList, &client.ListOptions{LabelSelector: s}); err != nil {
+	if err := r.List(context.TODO(), stsList, &client.ListOptions{LabelSelector: s, Namespace: req.NamespacedName.Namespace}); err != nil {
 		return ctrl.Result{}, err
 	}
 
@@ -134,7 +134,7 @@ func (r *RoleReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 	}
 
 	templateList := &tarantooliov1alpha1.ReplicasetTemplateList{}
-	if err := r.List(context.TODO(), templateList, &client.ListOptions{LabelSelector: templateSelector}); err != nil {
+	if err := r.List(context.TODO(), templateList, &client.ListOptions{LabelSelector: templateSelector, Namespace: req.NamespacedName.Namespace}); err != nil {
 		return ctrl.Result{}, err
 	}
 


### PR DESCRIPTION
This PR fixes buggy behaviour when starting multiple cartidge clusters with same name in different namespaces. 

How to reproduce issue:
- create 2 namespaces - test_1, test_2 
- install cartridge cluster with helm in both namespaces

The root cause is a lack of Namespace in List calls to k8s api which results in operator getting all resources across all namespaces instead of specific namespace.