### PR TITLE
Remove infinite reconciling of cluster controller

### DIFF
--- a/controllers/cluster_controller_test.go
+++ b/controllers/cluster_controller_test.go
@@ -41,7 +41,7 @@ func (c MockClient) Get(ctx context.Context, key client.ObjectKey, obj client.Ob
 	}
 	for _, o := range c.Items {
 		if key.Name == o.GetName() && key.Namespace == o.GetNamespace() {
-			obj = o
+			obj = o //nolint
 		}
 	}
 	return nil

--- a/controllers/cluster_controller_test.go
+++ b/controllers/cluster_controller_test.go
@@ -181,7 +181,7 @@ var _ = Describe("cluster_controller unit testing", func() {
 							return false
 						}
 
-						leader := cluster.GetAnnotations()["tarantool.io/topology-manage-leader"]
+						leader := cluster.GetAnnotations()["tarantool.io/topology-leader"]
 						return leader == expectedLeader
 					},
 					time.Second*10, time.Millisecond*500,
@@ -190,7 +190,7 @@ var _ = Describe("cluster_controller unit testing", func() {
 		})
 	})
 
-	Describe("cluster_controller.IsTopologyManageLeaderExists test", func() {
+	Describe("cluster_controller.IsTopologyLeaderExists test", func() {
 		Describe("the function must return true if the leader is exist and false if not exist", func() {
 			Context("positive cases (leader exist)", func() {
 				It("return True if leader assigned and exist", func() {
@@ -219,7 +219,7 @@ var _ = Describe("cluster_controller unit testing", func() {
 						Items: []client.Object{&stsList.Items[0]},
 					}
 
-					Expect(IsTopologyManageLeaderExists(c, &stsList, leader)).To(BeTrue())
+					Expect(IsTopologyLeaderExists(c, &stsList, leader)).To(BeTrue())
 				})
 			})
 
@@ -229,7 +229,7 @@ var _ = Describe("cluster_controller unit testing", func() {
 					stsList := appsv1.StatefulSetList{}
 
 					leader := utils.MakeStaticPodAddr("pod", "svc", "ns", "", 8081)
-					Expect(IsTopologyManageLeaderExists(c, &stsList, leader)).To(BeFalse())
+					Expect(IsTopologyLeaderExists(c, &stsList, leader)).To(BeFalse())
 				})
 
 				It("return False if leader not in the StatefulSet list", func() {
@@ -256,7 +256,7 @@ var _ = Describe("cluster_controller unit testing", func() {
 						Items: []client.Object{&stsList.Items[0]},
 					}
 
-					Expect(IsTopologyManageLeaderExists(c, &stsList, leader)).To(BeFalse())
+					Expect(IsTopologyLeaderExists(c, &stsList, leader)).To(BeFalse())
 				})
 			})
 		})

--- a/controllers/cluster_controller_test.go
+++ b/controllers/cluster_controller_test.go
@@ -36,6 +36,9 @@ type MockClient struct {
 }
 
 func (c MockClient) Get(ctx context.Context, key client.ObjectKey, obj client.Object) error {
+	if obj == nil {
+		return fmt.Errorf("required target object")
+	}
 	for _, o := range c.Items {
 		if key.Name == o.GetName() && key.Namespace == o.GetNamespace() {
 			obj = o
@@ -179,11 +182,7 @@ var _ = Describe("cluster_controller unit testing", func() {
 						}
 
 						leader := cluster.GetAnnotations()["tarantool.io/topology-manage-leader"]
-						if leader == expectedLeader {
-							return true
-						}
-
-						return false
+						return leader == expectedLeader
 					},
 					time.Second*10, time.Millisecond*500,
 				).Should(BeTrue())

--- a/controllers/cluster_controller_test.go
+++ b/controllers/cluster_controller_test.go
@@ -151,20 +151,20 @@ var _ = Describe("cluster_controller unit testing", func() {
 			AfterEach(func() {
 				rsTemplate := &tarantooliov1alpha1.ReplicasetTemplate{}
 				Expect(
-					k8sClient.Get(ctx, client.ObjectKey{Name: rsTemplateName, Namespace: namespace}, rsTemplate)
+					k8sClient.Get(ctx, client.ObjectKey{Name: rsTemplateName, Namespace: namespace}, rsTemplate),
 				).NotTo(HaveOccurred(), "failed to get ReplicasetTemplate")
 
 				Expect(
-					k8sClient.Delete(ctx, rsTemplate)
+					k8sClient.Delete(ctx, rsTemplate),
 				).NotTo(HaveOccurred(), "failed to delete ReplicasetTemplate")
 
 				pod := &corev1.Pod{}
 				Expect(
-					k8sClient.Get(ctx, client.ObjectKey{Name: podName, Namespace: namespace}, pod)
+					k8sClient.Get(ctx, client.ObjectKey{Name: podName, Namespace: namespace}, pod),
 				).NotTo(HaveOccurred(), "failed to get Pod")
 
 				Expect(
-					k8sClient.Delete(ctx, pod)
+					k8sClient.Delete(ctx, pod),
 				).NotTo(HaveOccurred(), "failed to delete Pod")
 			})
 

--- a/controllers/role_controller.go
+++ b/controllers/role_controller.go
@@ -126,10 +126,6 @@ func (r *RoleReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 			if stsAnnotations["tarantool.io/scheduledDelete"] == "1" {
 				reqLogger.Info("statefulset is ready for deletion")
 			}
-
-			// if err := r.client.Delete(context.TODO(), sts); err != nil {
-			// 	return reconcile.Result{}, err
-			// }
 		}
 	}
 
@@ -163,7 +159,7 @@ func (r *RoleReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 	}
 
 	for _, sts := range stsList.Items {
-		if template.Spec.Replicas != sts.Spec.Replicas {
+		if *template.Spec.Replicas != *sts.Spec.Replicas {
 			reqLogger.Info("Updating replicas count")
 			sts.Spec.Replicas = template.Spec.Replicas
 			if err := r.Update(context.TODO(), &sts); err != nil {
@@ -224,7 +220,6 @@ func (r *RoleReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 func (r *RoleReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&tarantooliov1alpha1.Role{}).
-		Watches(&source.Kind{Type: &tarantooliov1alpha1.Role{}}, &handler.EnqueueRequestForObject{}).
 		Watches(&source.Kind{Type: &appsv1.StatefulSet{}}, &handler.EnqueueRequestForOwner{
 			IsController: true,
 			OwnerType:    &tarantooliov1alpha1.Role{},
@@ -232,7 +227,7 @@ func (r *RoleReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Watches(&source.Kind{Type: &tarantooliov1alpha1.ReplicasetTemplate{}}, handler.EnqueueRequestsFromMapFunc(func(a client.Object) []reconcile.Request {
 			roleList := &tarantooliov1alpha1.RoleList{}
 			if err := r.Client.List(context.TODO(), roleList, &client.ListOptions{}); err != nil {
-				mgr.GetLogger().Info("FUCK")
+				mgr.GetLogger().Info("Error getting list of ReplicasetTemplate in mgr.Watches")
 			}
 
 			res := []reconcile.Request{}

--- a/controllers/topology/builtin.go
+++ b/controllers/topology/builtin.go
@@ -13,6 +13,8 @@ import (
 	"github.com/machinebox/graphql"
 	corev1 "k8s.io/api/core/v1"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/tarantool/tarantool-operator/controllers/utils"
 )
 
 // ResponseError .
@@ -217,11 +219,10 @@ func (s *BuiltInTopologyService) Join(pod *corev1.Pod) error {
 		clusterDomainName = "cluster.local"
 	}
 
-	advURI := fmt.Sprintf("%s.%s.%s.svc.%s:3301",
-		pod.GetObjectMeta().GetName(),      // Instance name
-		s.clusterID,                        // Cartridge cluster name
-		pod.GetObjectMeta().GetNamespace(), // Namespace
-		clusterDomainName)                  // Cluster domain name
+	podMeta := pod.GetObjectMeta()
+
+	advURI := utils.MakeStaticPodAddr(
+		podMeta.GetName(), s.clusterID, podMeta.GetNamespace(), clusterDomainName, 3301)
 
 	replicasetUUID, ok := thisPodLabels["tarantool.io/replicaset-uuid"]
 	if !ok {

--- a/controllers/utils/utils.go
+++ b/controllers/utils/utils.go
@@ -1,5 +1,9 @@
 package utils
 
+import (
+	"fmt"
+)
+
 func IsRolesEquals(rolesA, rolesB []string) bool {
 	isSubset := func(X, Y []string) bool {
 		for _, x := range X {
@@ -17,4 +21,16 @@ func IsRolesEquals(rolesA, rolesB []string) bool {
 		return true
 	}
 	return isSubset(rolesA, rolesB) && isSubset(rolesB, rolesA)
+}
+
+func MakeStaticPodAddr(pod string, svc string, ns string, domain string, port int) string {
+	if port == 0 {
+		port = 8081
+	}
+
+	if domain == "" {
+		domain = "cluster.local"
+	}
+
+	return fmt.Sprintf("%s.%s.%s.svc.%s:%d", pod, svc, ns, domain, port)
 }

--- a/test/helpers/resource_factory.go
+++ b/test/helpers/resource_factory.go
@@ -187,14 +187,9 @@ func NewReplicasetTemplate(params ReplicasetTemplateParams) tarantooliov1alpha1.
 					// },
 					Containers: []corev1.Container{
 						{
-							Name:  params.ContainerName,
-							Image: params.ContainerImage,
-							VolumeMounts: []corev1.VolumeMount{
-								{
-									Name:      "www",
-									MountPath: "/var/lib/tarantool",
-								},
-							},
+							Name:         params.ContainerName,
+							Image:        params.ContainerImage,
+							VolumeMounts: []corev1.VolumeMount{},
 							// SecurityContext: &corev1.SecurityContext{
 							// 	Capabilities: &corev1.Capabilities{
 							// 		Add: []corev1.Capability{


### PR DESCRIPTION
### Problem

Infinite cluster controller reconciling to "sync".

Most relevant is for roles list updating. The cluster controller requests the list of roles from the cartridge api and compare it with the list in ReplicasetTemplate.

But, cartridge receive list with dependencies (https://github.com/tarantool/cartridge/issues/1722). Therefore, on each reconciling, the roles are updated.

Now, reconciling are usually because we need to update the leader (pod uses for run for manage topology) and the leader is stored in the Endpoints resource annotation.

### Solve

I moved the leader (renamed it to topology-manage-leader) in the cluster annotation and as the address I use dns host name of the pod.

### Drawbacks

We will not be able to respond to changes that occur on the side of Cartridge. Do we need to set up probes for this?

Closes #114 