### PR TITLE
Upgrade code and docs for easy start

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -143,7 +143,7 @@ helm-uninstall-operator: ## Uninstall tarantool-operator.
 	helm uninstall -n tarantool-operator operator
 
 helm-install-cartridge-app: ## Install cartridge-app with tarantool-cartridge helm chart.
-	helm install -n tarantool-app cartridge-app $(CHARTS_DIR)/tarantool-cartridge \
+	helm upgrade --install -n tarantool-app cartridge-app $(CHARTS_DIR)/tarantool-cartridge \
 	             --create-namespace \
 	             --set LuaMemoryReserveMB=0 # default reserve too large for local minikube cluster
 

--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ Tarantool Operator is up and running.
     Wait until all the cluster Pods are up (status becomes `Running`):
 
     ```shell
-    $ kubectl -n cartridge-app get pods
+    $ kubectl -n tarantool-app get pods
     ---
     NAME          READY   STATUS    RESTARTS   AGE
     routers-0-0   1/1     Running   0          6m12s
@@ -200,7 +200,7 @@ Tarantool Operator is up and running.
 3. Access the cluster web UI:
 
     ```shell
-    $ kubectl -n cartridge-app port-forward routers-0-0 8081:8081
+    $ kubectl -n tarantool-app port-forward routers-0-0 8081:8081
     ---
     Forwarding from 127.0.0.1:8081 -> 8081
     Forwarding from [::1]:8081 -> 8081
@@ -217,14 +217,30 @@ Tarantool Operator is up and running.
        {"info":"Successfully created"}
        ```
 
-   2. Access stored values:
+   2. Access stored value:
 
        ```shell
-       $ curl http://localhost:8081/kv_dump
+       $ curl http://localhost:8081/kv/key_1
        ---
-       {"store":[{"key":"key_1","value":"value_1"}]}
+       "value_1"
        ```
 
+   3. Update stored value:
+
+       ```shell
+       $ curl -XPUT http://localhost:8081/kv/key_1 -d '"new_value_1"'
+       ---
+       ["key_1", "new_value_1"]
+       ```
+          
+   4. Delete stored value:
+
+       ```shell
+       $ curl -XDELETE http://localhost:8081/kv/key_1
+       ---
+       {"info":"Successfully deleted"}
+       ```
+      
 ### Scaling the application
 
 Increase the number of replica sets in Storages Role:

--- a/examples/kv/app/roles/router.lua
+++ b/examples/kv/app/roles/router.lua
@@ -50,10 +50,10 @@ end
 
 local function handle_update(req)
     local key = req:stash('key')
-    local status, value = pcall(function() return req:json() end)
+    local _, value = pcall(function() return req:json() end)
 
-    if value == nil or type(value) == 'string' then
-        local resp = req:render{json = { info = msg }}
+    if value == nil then
+        local resp = req:render{json = { info = "Value cannot be empty" }}
         resp.status = 500
         return resp
     end

--- a/helm-charts/tarantool-cartridge/values.yaml
+++ b/helm-charts/tarantool-cartridge/values.yaml
@@ -8,7 +8,7 @@ LuaMemoryReserveMB: 2048
 
 image:
   repository: tarantool/tarantool-operator-examples-kv
-  tag: 0.0.3
+  tag: 0.0.4
   pullPolicy: IfNotPresent
 
 securityContext:


### PR DESCRIPTION
Allow example kv app to accept string as value in PUT method, fix namespace in documentation and allow upgrade example kv app helm deployment through makefile.

PS: We should build and push tarantool/tarantool-operator-examples-kv:0.0.4 at hub.docker.com before merge