### PR TITLE
go1.18 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,10 +25,10 @@ jobs:
     steps:
     - uses: actions/checkout@v1
 
-    - name: Set up Go 1.17
+    - name: Set up Go 1.18
       uses: actions/setup-go@v1
       with:
-        go-version: 1.17
+        go-version: 1.18
       id: go
 
     - name: Set up Kubebuilder

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.16 as builder
+FROM golang:1.18 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 0.0.9
+VERSION ?= 0.0.11
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")

--- a/Makefile
+++ b/Makefile
@@ -168,17 +168,17 @@ undeploy: ## Undeploy controller from the K8s cluster specified in ~/.kube/confi
 
 CONTROLLER_GEN = $(shell pwd)/bin/controller-gen
 controller-gen: ## Download controller-gen locally if necessary.
-	$(call go-get-tool,$(CONTROLLER_GEN),sigs.k8s.io/controller-tools/cmd/controller-gen@v0.7.0)
+	$(call go-get-tool,$(CONTROLLER_GEN),sigs.k8s.io/controller-tools/cmd/controller-gen,v0.7.0)
 
 KUSTOMIZE = $(shell pwd)/bin/kustomize
 kustomize: ## Download kustomize locally if necessary.
-	$(call go-get-tool,$(KUSTOMIZE),sigs.k8s.io/kustomize/kustomize/v3@v3.8.7)
+	$(call go-get-tool,$(KUSTOMIZE),sigs.k8s.io/kustomize/kustomize/v3,v3.10.0)
 
 ENVTEST = $(shell pwd)/bin/setup-envtest
 envtest: ## Download envtest-setup locally if necessary.
-	$(call go-get-tool,$(ENVTEST),sigs.k8s.io/controller-runtime/tools/setup-envtest@latest)
+	$(call go-get-tool,$(ENVTEST),sigs.k8s.io/controller-runtime/tools/setup-envtest,latest)
 
-# go-get-tool will 'go get' any package $2 and install it to $1.
+# go-get-tool will 'go get' any package $2 in version $3 and install it to $1.
 PROJECT_DIR := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))
 define go-get-tool
 @[ -f $(1) ] || { \
@@ -186,8 +186,11 @@ set -e ;\
 TMP_DIR=$$(mktemp -d) ;\
 cd $$TMP_DIR ;\
 go mod init tmp ;\
-echo "Downloading $(2)" ;\
-GOBIN=$(PROJECT_DIR)/bin go get $(2) ;\
+echo "Downloading $(2)@$(3)" ;\
+GO_VERSION=`go version | { read _ _ v _; echo $${v#go}; }` ; \
+GOBIN=$(PROJECT_DIR)/bin go get $(2)@$(3) ; \
+echo "Go version is $$GO_VERSION" ; \
+(printf '%s\n%s\n' "1.18" $$GO_VERSION  | sort --check=quiet --version-sort) && GOBIN=$(PROJECT_DIR)/bin go install $(2) ; \
 rm -rf $$TMP_DIR ;\
 }
 endef

--- a/helm-charts/tarantool-cartridge/Chart.yaml
+++ b/helm-charts/tarantool-cartridge/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for tarantool
 name: cartridge
-version: 0.0.10
+version: 0.0.11

--- a/helm-charts/tarantool-operator/Chart.yaml
+++ b/helm-charts/tarantool-operator/Chart.yaml
@@ -5,7 +5,7 @@ description: kubernetes tarantool operator
 type: application
 
 # Helm chart Version
-version: 0.0.10
+version: 0.0.11
 
 # Application version to be deployed
 appVersion: 1.16.0

--- a/helm-charts/tarantool-operator/values.yaml
+++ b/helm-charts/tarantool-operator/values.yaml
@@ -4,5 +4,5 @@
 
 image:
   repository: tarantool/tarantool-operator
-  tag: 0.0.10
+  tag: 0.0.11
   pullPolicy: IfNotPresent


### PR DESCRIPTION
### Why?

Cause [go 1.18 is released](https://go.dev/blog/go1.18)

### Why we need some changes?

Cuase in go 1.17 installing executables by calling  'go get' was [deprecated](https://go.dev/doc/go-get-install-deprecation) and in go 1.18 it was [dropped](https://tip.golang.org/doc/go1.18)

> go get no longer builds or installs packages in module-aware mode. go get is now dedicated to adjusting dependencies in go.mod.