### PR TITLE
Set PublishNotReadyAddresses true for cluster wide Service

### DIFF
--- a/controllers/cluster_controller.go
+++ b/controllers/cluster_controller.go
@@ -176,8 +176,9 @@ func (r *ClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 			svc.Name = cluster.GetName()
 			svc.Namespace = cluster.GetNamespace()
 			svc.Spec = corev1.ServiceSpec{
-				Selector:  cluster.Spec.Selector.MatchLabels,
-				ClusterIP: "None",
+				PublishNotReadyAddresses: true,
+				Selector:                 cluster.Spec.Selector.MatchLabels,
+				ClusterIP:                "None",
 				Ports: []corev1.ServicePort{
 					{
 						Name:     "app",


### PR DESCRIPTION
Set PublishNotReadyAddresses true for cluster wide Service.

The primary use case for setting this field is for a StatefulSet's Headless Service to propagate SRV/A DNS records for its Pods for the purpose of peer discovery.