### PR TITLE
repeat the loop to wait for the roles phases, not end it

### DIFF
--- a/pkg/reconciliation/steps/cluster/wait_for_roles_phase.go
+++ b/pkg/reconciliation/steps/cluster/wait_for_roles_phase.go
@@ -1,6 +1,8 @@
 package cluster
 
 import (
+	"time"
+
 	"github.com/tarantool/tarantool-operator/pkg/api"
 	. "github.com/tarantool/tarantool-operator/pkg/reconciliation"
 )
@@ -30,5 +32,5 @@ func (r *WaitForRolesPhaseStep[RolePhaseType, ClusterType, CtxType, CtrlType]) R
 		}
 	}
 
-	return Complete()
+	return Requeue(10 * time.Second)
 }


### PR DESCRIPTION
Looks like a bug that stops cluster processing when roles are not in one of the expected phases