### PR TITLE
Fix: non-leader instances must be joined through an joined leader

### DIFF
--- a/pkg/reconciliation/steps/role/join_instances.go
+++ b/pkg/reconciliation/steps/role/join_instances.go
@@ -120,7 +120,7 @@ func (r *JoinInstancesStep[PhaseType, RoleType, CtxType, CtrlType]) Reconcile(ct
 							return Complete()
 						}
 
-						return Error(err)
+						return Error(joinErr)
 					}
 				}
 			}

--- a/pkg/reconciliation/steps/role/join_instances.go
+++ b/pkg/reconciliation/steps/role/join_instances.go
@@ -72,10 +72,25 @@ func (r *JoinInstancesStep[PhaseType, RoleType, CtxType, CtrlType]) Reconcile(ct
 				if uuidErr != nil {
 					ctx.GetLogger().Error(uuidErr, "unable to get instance uuid")
 
-					return Error(err)
+					return Error(uuidErr)
 				}
 
 				if instanceUUID == "" {
+					leader := ctx.GetLeader()
+
+					if leader.Name != pod.Name {
+						switch leaderUUID, uuidErr := topologyClient.GetInstanceUUID(ctx, leader); {
+						case uuidErr != nil:
+							ctx.GetLogger().Error(uuidErr, "unable to get leader instance uuid")
+
+							return Error(uuidErr)
+						case leaderUUID == "":
+							allJoined = false
+
+							continue
+						}
+					}
+
 					vshard := role.GetVShardConfig()
 
 					alias, err := role.GetReplicasetName(stsOrdinal)
@@ -85,7 +100,7 @@ func (r *JoinInstancesStep[PhaseType, RoleType, CtxType, CtrlType]) Reconcile(ct
 
 					joinErr := topologyClient.Join(
 						ctx,
-						ctx.GetLeader(),
+						leader,
 						alias,
 						ctrl.GetReplicasetsManger().GetReplicasetUUID(role, stsOrdinal),
 						vshard.GetRoles(),


### PR DESCRIPTION
Fixing the situation when instances joined before the leader form separate clusters because its do not saved into the leader's topology. So leader must be joined firstly.