### PR TITLE
Allow to elect leader with OperationError state

### DIFF
--- a/pkg/topology/common.go
+++ b/pkg/topology/common.go
@@ -432,7 +432,7 @@ func (r *CommonCartridgeTopology) IsCartridgeConfigured(ctx context.Context, pod
 		local confapplier = require('cartridge.confapplier')
 		local state = confapplier.get_state()
 
-		if state ~= 'RolesConfigured' then
+		if state ~= 'RolesConfigured' and state ~= 'OperationError' then
 			return { res = false, err=nil }
 		end
 


### PR DESCRIPTION
OperationError is also a valid state to call config_patch_clusterwide (edit_topology/apply_config)