### PR TITLE
Join StatefulSet instances in one request

### DIFF
--- a/pkg/topology/common.go
+++ b/pkg/topology/common.go
@@ -30,8 +30,14 @@ func (r *CommonCartridgeTopology) Join(
 	replicasetWeight int32,
 	replicasetVshardGroup string,
 	replicasetIsAllRw bool,
-	advertiseURI string,
+	advertiseURIs ...string,
 ) error {
+	joinServers := make([]JoinServerParams, len(advertiseURIs))
+
+	for i, uri := range advertiseURIs {
+		joinServers[i].URI = uri
+	}
+
 	editTopology := EditTopologyParams{
 		Replicasets: []EditReplicasetParams{
 			{
@@ -41,9 +47,7 @@ func (r *CommonCartridgeTopology) Join(
 				Weight:      replicasetWeight,
 				VShardGroup: replicasetVshardGroup,
 				AllRw:       replicasetIsAllRw,
-				JoinServers: []JoinServerParams{{
-					URI: advertiseURI,
-				}},
+				JoinServers: joinServers,
 			},
 		},
 	}

--- a/pkg/topology/topology.go
+++ b/pkg/topology/topology.go
@@ -19,7 +19,7 @@ type CartridgeTopology interface {
 		replicasetWeight int32,
 		replicasetVshardGroup string,
 		replicasetIsAllRw bool,
-		advertiseURI string,
+		advertiseURIs ...string,
 	) error
 
 	GetInstanceUUID(ctx context.Context, pod *v1.Pod) (string, error)

--- a/test/mocks/topology.go
+++ b/test/mocks/topology.go
@@ -29,7 +29,7 @@ func (f *FakeCartridgeTopology) Join(
 	replicasetWeight int32,
 	replicasetVshardGroup string,
 	replicasetIsAllRw bool,
-	advertiseURI string,
+	advertiseURI ...string,
 ) error {
 	args := f.Called(
 		ctx,


### PR DESCRIPTION
Joining instances one by one to a set of replicas during its creation can cause issues with replication, sharding, raft...

Joining StatefulSet instances in one request solves these problems because there are no orphan instances during the replicaset enablement process.